### PR TITLE
削除時の認証チェックの追加

### DIFF
--- a/backend/src/modules/memo/application/commands/delete-memo/delete-memo.command.ts
+++ b/backend/src/modules/memo/application/commands/delete-memo/delete-memo.command.ts
@@ -1,3 +1,6 @@
 export class DeleteMemoCommand {
-  constructor(readonly memoId: string) {}
+  constructor(
+    readonly userId: string,
+    readonly memoId: string,
+  ) {}
 }

--- a/backend/src/modules/memo/application/commands/delete-memo/delete-memo.usecase.spec.ts
+++ b/backend/src/modules/memo/application/commands/delete-memo/delete-memo.usecase.spec.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { DeleteMemoUseCase } from './delete-memo.usecase';
+import { DeleteMemoCommand } from './delete-memo.command';
+import { MemoRepository } from 'src/modules/memo/domain/memo.repository';
+import { Memo } from 'src/modules/memo/domain/entities/memo.entity';
+import { MemoNotFoundApplicationError } from '../../errors/memo-not-found.error';
+import { MemoNotOwnedError } from '../../errors/memo-not-owned.error';
+
+describe('DeleteMemoUseCase', () => {
+  let useCase: DeleteMemoUseCase;
+  let memoRepository: jest.Mocked<MemoRepository>;
+
+  beforeEach(() => {
+    memoRepository = {
+      create: jest.fn(),
+      update: jest.fn(),
+      findById: jest.fn(),
+      findByUserId: jest.fn(),
+      delete: jest.fn(),
+    };
+    useCase = new DeleteMemoUseCase(memoRepository);
+  });
+
+  describe('正常系', () => {
+    it('メモの所持者であれば削除できる', async () => {
+      const userId = 'user-123';
+      const memoId = 'memo-456';
+      const memo = Memo.from(
+        memoId,
+        userId,
+        'Test Title',
+        'Test Content',
+        new Date(),
+        new Date(),
+      );
+
+      memoRepository.findById.mockResolvedValue(memo);
+      memoRepository.delete.mockResolvedValue(undefined);
+
+      const command = new DeleteMemoCommand(userId, memoId);
+      await useCase.execute(command);
+
+      expect(memoRepository.findById).toHaveBeenCalledWith(memoId);
+      expect(memoRepository.delete).toHaveBeenCalledWith(memoId);
+    });
+  });
+
+  describe('異常系', () => {
+    it('メモが存在しない場合はMemoNotFoundApplicationErrorを投げる', async () => {
+      const userId = 'user-123';
+      const memoId = 'non-existent-memo';
+
+      memoRepository.findById.mockResolvedValue(null);
+
+      const command = new DeleteMemoCommand(userId, memoId);
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        MemoNotFoundApplicationError,
+      );
+      expect(memoRepository.findById).toHaveBeenCalledWith(memoId);
+      expect(memoRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('メモの所持者でない場合はMemoNotOwnedErrorを投げる', async () => {
+      const ownerId = 'owner-123';
+      const otherUserId = 'other-user-456';
+      const memoId = 'memo-789';
+      const memo = Memo.from(
+        memoId,
+        ownerId,
+        'Test Title',
+        'Test Content',
+        new Date(),
+        new Date(),
+      );
+
+      memoRepository.findById.mockResolvedValue(memo);
+
+      const command = new DeleteMemoCommand(otherUserId, memoId);
+
+      await expect(useCase.execute(command)).rejects.toThrow(MemoNotOwnedError);
+      expect(memoRepository.findById).toHaveBeenCalledWith(memoId);
+      expect(memoRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/memo/application/commands/delete-memo/delete-memo.usecase.ts
+++ b/backend/src/modules/memo/application/commands/delete-memo/delete-memo.usecase.ts
@@ -1,6 +1,7 @@
 import { MemoRepository } from 'src/modules/memo/domain/memo.repository';
 import { DeleteMemoCommand } from './delete-memo.command';
 import { MemoNotFoundApplicationError } from '../../errors/memo-not-found.error';
+import { MemoNotOwnedError } from '../../errors/memo-not-owned.error';
 
 export class DeleteMemoUseCase {
   constructor(private readonly memoRepository: MemoRepository) {}
@@ -8,6 +9,9 @@ export class DeleteMemoUseCase {
     const memo = await this.memoRepository.findById(command.memoId);
     if (!memo) {
       throw new MemoNotFoundApplicationError(command.memoId);
+    }
+    if (memo.userId !== command.userId) {
+      throw new MemoNotOwnedError(command.memoId, command.userId);
     }
     await this.memoRepository.delete(command.memoId);
   }

--- a/backend/src/modules/memo/application/errors/memo-not-owned.error.ts
+++ b/backend/src/modules/memo/application/errors/memo-not-owned.error.ts
@@ -1,0 +1,11 @@
+export class MemoNotOwnedError extends Error {
+  readonly memoId: string;
+  readonly userId: string;
+
+  constructor(memoId: string, userId: string) {
+    super(`このメモを操作する権限がありません: memoId:${memoId}`);
+    this.name = 'MemoNotOwnedError';
+    this.memoId = memoId;
+    this.userId = userId;
+  }
+}

--- a/backend/src/modules/memo/presentation/memo.controller.ts
+++ b/backend/src/modules/memo/presentation/memo.controller.ts
@@ -62,8 +62,11 @@ export class MemoController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async delete(@Param('id') id: string): Promise<void> {
-    const command = new DeleteMemoCommand(id);
+  async delete(
+    @CurrentUser() user: CurrentUser,
+    @Param('id') id: string,
+  ): Promise<void> {
+    const command = new DeleteMemoCommand(user.userId, id);
     await this.deleteMemoUseCase.execute(command);
   }
 }


### PR DESCRIPTION
## 変更点

- 削除時の認可チェックを追加しました
- テストコードも追加しました

## Issue
Fixes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモ削除時に所有権確認機能を追加しました。ユーザーは自分が作成したメモのみ削除可能になります。

* **バグ修正**
  * 認証されたユーザーのみがメモ削除操作を実行できるようになりました。

* **テスト**
  * メモ削除機能のユニットテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->